### PR TITLE
Improvements to avoid the syslog error from blkid cmd.

### DIFF
--- a/backupmon.sh
+++ b/backupmon.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Original functional backup script by: @Jeffrey Young, August 9, 2023
-# BACKUPMON v1.5.10 heavily modified and restore functionality added by @Viktor Jaep, 2023
+# BACKUPMON v1.5.11 heavily modified and restore functionality added by @Viktor Jaep, 2023
 #
 # BACKUPMON is a shell script that provides backup and restore capabilities for your Asus-Merlin firmware router's JFFS and
 # external USB drive environments. By creating a network share off a NAS, server, or other device, BACKUPMON can point to
@@ -16,7 +16,7 @@
 # Please use the 'backupmon.sh -setup' command to configure the necessary parameters that match your environment the best!
 
 # Variable list -- please do not change any of these
-Version="1.5.10"                                                # Current version
+Version="1.5.11"                                                # Current version
 Beta=0                                                          # Beta release Y/N
 CFGPATH="/jffs/addons/backupmon.d/backupmon.cfg"                # Path to the backupmon config file
 DLVERPATH="/jffs/addons/backupmon.d/version.txt"                # Path to the backupmon version file
@@ -1736,7 +1736,7 @@ _GetDefaultUSBMountPoint_()
 # -------------------------------------------------------------------------------------------------------------------------
 
 ##----------------------------------------##
-## Modified by Martinski W. [2024-Feb-29] ##
+## Modified by Martinski W. [2024-Mar-03] ##
 ##----------------------------------------##
 #---------------------------------------------------------#
 # The USB-attached drives may have multiple partitions
@@ -1750,14 +1750,15 @@ _GetDefaultUSBMountPoint_()
 _CheckForMountPointAndVolumeLabel_()
 {
    local theLabel  foundLabelOK=false
-   local mounPointPaths  nvramLabels  blkidLabels  
+   local mounPointDevSD  mounPointPaths  nvramLabels  blkidLabels  
    local mountPointRegExp="^/dev/sd.* /tmp/mnt/.*"
 
+   mounPointDevSD="$(grep -E "$mountPointRegExp" /proc/mounts | awk -F ' ' '{print $1}')"
    mounPointPaths="$(grep -E "$mountPointRegExp" /proc/mounts | awk -F ' ' '{print $2}')"
    [ -z "$mounPointPaths" ] && echo "" && return 1
 
-   blkidLabels="$(blkid | grep "^/dev/sd.*: LABEL=" | sort -dt ':' -k 1 | awk -F ' ' '{print $2}' | awk -F '"' '{print $2}')"
    nvramLabels="$(nvram show 2>/dev/null | grep -E "^usb_path_sd[a-z][0-9]_label=" | sort -dt '_' -k 3 | awk -F '=' '{print $2}')"
+   blkidLabels="$(blkid $mounPointDevSD | grep "^/dev/sd.*: LABEL=" | sort -dt ':' -k 1 | awk -F ' ' '{print $2}' | awk -F '"' '{print $2}')"
    { [ -z "$blkidLabels" ] && [ -z "$nvramLabels" ] ; } && echo "" && return 1
 
    theLabel=""


### PR DESCRIPTION
Code improvements to avoid the syslog error when using the **blkid** command.